### PR TITLE
rearrange order between css and js

### DIFF
--- a/interface/common/blog/begin.php
+++ b/interface/common/blog/begin.php
@@ -15,16 +15,17 @@ if (!isset($skin))
 	$skin = new Skin($skinSetting['skin']);
 $context = Model_Context::getInstance();
 $view = $skin->outter;
-$view = str_replace('[##_SKIN_head_end_##]',getScriptsOnHead().'[##_SKIN_head_end_##]', $view); // TO DO : caching this part.
-$view = str_replace('[##_SKIN_body_start_##]',getUpperView(isset($paging) ? $paging : null).'[##_SKIN_body_start_##]', $view);
-$view = str_replace('[##_SKIN_body_end_##]',getLowerView().getScriptsOnFoot().'[##_SKIN_body_end_##]', $view); // care the order for js function overloading issue.
 $automaticLink = "	<link rel=\"stylesheet\" href=\"".$context->getProperty('service.resourcepath')."/style/system.css\" type=\"text/css\" media=\"screen\" />\n";
 if (!is_null($context->getProperty('uri.permalink',null))) {
 	$canonicalLink = "  <link rel=\"canonical\" href=\"".$context->getProperty('uri.permalink')."\"/>\n";
 } else {
 	$canonicalLink = '';
 }
-dress('SKIN_head_end', $canonicalLink.$automaticLink."[##_SKIN_head_end_##]", $view);
+dress('SKIN_head_end', $automaticLink.$canonicalLink."[##_SKIN_head_end_##]", $view);
+$view = str_replace('[##_SKIN_head_end_##]',getScriptsOnHead().'[##_SKIN_head_end_##]', $view); // TO DO : caching this part.
+$view = str_replace('[##_SKIN_body_start_##]',getUpperView(isset($paging) ? $paging : null).'[##_SKIN_body_start_##]', $view);
+$view = str_replace('[##_SKIN_body_end_##]',getLowerView().getScriptsOnFoot().'[##_SKIN_body_end_##]', $view); // care the order for js function overloading issue.
+
 $browserUtil = Utils_Browser::getInstance();
 if(Setting::getBlogSettingGlobal('useiPhoneUI',true) && ($browserUtil->isMobile() == true)) {
 	if ($context->getProperty('suri.id',null)!=null) {


### PR DESCRIPTION
`system.css` is below js files(such like `EAF4.js`, `common2.js`)
so it cause down browser redering performance.
refer
https://developers.google.com/speed/docs/best-practices/rtt#PutStylesBeforeScripts
## before:

`system.css` is under javascript files.

``` html
<link type="text/css" rel="stylesheet" href="/plugins/CodeHighlighter/styles/shThemeRDark.css" />
<script type="text/javascript" src="/resources/script/jquery/jquery-1.6.4.min.js"></script>
<script type="text/javascript">jQuery.noConflict();</script>
<script type="text/javascript" src="/resources/script/EAF4.js"></script>
<script type="text/javascript" src="/resources/script/common2.js"></script>
<script type="text/javascript" src="/resources/script/gallery.js" ></script>
<script type="text/javascript" src="/resources/script/flash.js" ></script>
<link rel="canonical" href=""/>
<link rel="stylesheet" href="/resources/style/system.css" type="text/css" media="screen" />
```
## after:

`system.css` move to top of javascrript files

``` html
<link type="text/css" rel="stylesheet" href="/plugins/CodeHighlighter/styles/shThemeRDark.css" />
<link rel="stylesheet" href="/resources/style/system.css" type="text/css" media="screen" />
<link rel="canonical" href=""/>
<script type="text/javascript" src="/resources/script/jquery/jquery-1.6.4.min.js"></script>
<script type="text/javascript">jQuery.noConflict();</script>
<script type="text/javascript" src="/resources/script/EAF4.js"></script>
<script type="text/javascript" src="/resources/script/common2.js"></script>
<script type="text/javascript" src="/resources/script/gallery.js" ></script>
<script type="text/javascript" src="/resources/script/flash.js" ></script>
```
