### PR TITLE
Javascript mime type

### DIFF
--- a/library/function/file.php
+++ b/library/function/file.php
@@ -55,6 +55,8 @@ function getMIMEType($ext, $filename = null) {
 				return 'application/x-hwp';
 			case 'pdf':
 				return 'application/pdf';
+			case 'js':
+				return 'application/javascript';
 			case 'odt':case 'ott':
 				return 'application/vnd.oasis.opendocument.text';
 			case 'ods':case 'ots':


### PR DESCRIPTION
There isn't MIMEType for javascript In `getMIMEType`, 
so javascript files don't have content type and
browser reconize the files as `text/plain` 

``` shell
$ curl -I http://blog.outsider.ne.kr/resources/script/EAF4.js
HTTP/1.1 200 OK
Server: nginx/1.4.1
Content-Length: 20996
Connection: keep-alive
X-Powered-By: PHP/5.4.9-4ubuntu2
Last-Modified: Sat, 1 Mar 2014 19:00:00 GMT
Date: Sun, 9 Mar 2014 11:23:43  GMT
Expires: Mon, 10 Mar 2014 11:23:43 GMT
Cache-Control: max-age=86400
Pragma: cache
ETag: textcube-56c6dee0
```

after add `application/javascript` MIME type for `js`

``` shell
$ curl -I http://blog.outsider.ne.kr/resources/script/EAF4.js
HTTP/1.1 200 OK
Server: nginx/1.4.1
Content-Type: application/javascript
Content-Length: 20996
Connection: keep-alive
Vary: Accept-Encoding
X-Powered-By: PHP/5.4.9-4ubuntu2
Last-Modified: Sat, 1 Mar 2014 19:00:00 GMT
Date: Sun, 9 Mar 2014 11:24:04  GMT
Expires: Mon, 10 Mar 2014 11:24:04 GMT
Cache-Control: max-age=86400
Pragma: cache
ETag: textcube-56c6dee0
```
