### PR TITLE
Windows 서버에서 이미지 사이즈 구하기 오류 수정

### DIFF
--- a/library/model/blog.attachment.php
+++ b/library/model/blog.attachment.php
@@ -147,7 +147,10 @@ function addAttachment($blogid, $parent, $file) {
 		$attachment['name'] = rand(1000000000, 9999999999) . ".$extension";
 		$attachment['path'] = "$path/{$attachment['name']}";
 	} while (file_exists($attachment['path']));
-	if ($imageAttributes = @getimagesize($file['tmp_name'])) {
+	if (!move_uploaded_file($file['tmp_name'], $attachment['path']))
+		return false;
+	@chmod($attachment['path'], 0666);
+	if ($imageAttributes = @getimagesize($attachment['path'])) {
 		$attachment['mime'] = $imageAttributes['mime'];
 		$attachment['width'] = $imageAttributes[0];
 		$attachment['height'] = $imageAttributes[1];
@@ -156,9 +159,6 @@ function addAttachment($blogid, $parent, $file) {
 		$attachment['width'] = 0;
 		$attachment['height'] = 0;
 	}
-	if (!move_uploaded_file($file['tmp_name'], $attachment['path']))
-		return false;
-	@chmod($attachment['path'], 0666);
 	$attachment['label'] = UTF8::lessenAsEncoding($attachment['label'], 64);
 	$attachment['mime']  = UTF8::lessenAsEncoding($attachment['mime'], 32);
 


### PR DESCRIPTION
Windows 서버에서는 tmp_name 상에 있는 파일로 이미지 사이즈를 구하는 것이 올바르게 작동하지 않습니다.

$file['tmp_name'] 으로 구하는 부분을 업로드 처리가 완료된 후, $attachment['path'] 값으로 이미지 사이즈를 구하도록 수정하여야 Windows 서버에서 올바르게 작동합니다.
