### PR TITLE
Fix difference of imageblock caption HTML structure on mobile

### DIFF
--- a/plugins/FM_TTML/ttml.php
+++ b/plugins/FM_TTML/ttml.php
@@ -269,7 +269,7 @@ function FM_TTML_bindAttachments($entryId, $folderPath, $folderURL, $content, $u
 					list($newProperty, $onclickFlag) = FM_TTML_createNewProperty($attributes[1], $contentWidth, $attributes[2]);
 
 					if ($context->getProperty('blog.displaymode','desktop')=='mobile') {
-						$buf = '<div class="imageblock center">' . FM_TTML_getAttachmentBinder($attributes[1], $newProperty, $folderPath, $folderURL, 1, $useAbsolutePath) . "</div><div class=\"cap1\">$attributes[3]</div>";
+						$buf = '<div class="imageblock center">' . FM_TTML_getAttachmentBinder($attributes[1], $newProperty, $folderPath, $folderURL, 1, $useAbsolutePath) . "<p class=\"cap1\">$attributes[3]</p></div>";
 					} else {
 						if (trim($attributes[3]) == '') {
 							$caption = '';
@@ -296,8 +296,8 @@ function FM_TTML_bindAttachments($entryId, $folderPath, $folderURL, $content, $u
 					list($newProperty1, $onclickFlag1) = FM_TTML_createNewProperty($attributes[1], $eachImageWidth, $attributes[2]);
 					list($newProperty2, $onclickFlag2) = FM_TTML_createNewProperty($attributes[4], $eachImageWidth, $attributes[5]);
 					if ($context->getProperty('blog.displaymode','desktop')=='mobile') {
-						$buf = '<div>' . FM_TTML_getAttachmentBinder($attributes[1], $newProperty1, $folderPath, $folderURL, 1, $useAbsolutePath, $bRssMode) . "</div><div class=\"cap1\">$attributes[3]</div>";
-						$buf .= '<div>' . FM_TTML_getAttachmentBinder($attributes[4], $newProperty2, $folderPath, $folderURL, 1, $useAbsolutePath, $bRssMode) . "</div><div class=\"cap1\">$attributes[6]</div>";
+						$buf = '<div>' . FM_TTML_getAttachmentBinder($attributes[1], $newProperty1, $folderPath, $folderURL, 1, $useAbsolutePath, $bRssMode) . "<p class=\"cap1\">$attributes[3]</p></div>";
+						$buf .= '<div>' . FM_TTML_getAttachmentBinder($attributes[4], $newProperty2, $folderPath, $folderURL, 1, $useAbsolutePath, $bRssMode) . "<p class=\"cap1\">$attributes[6]</p></div>";
 					} else {
 						$cap1 = strlen(trim($attributes[3])) > 0 ? '<p class="cap1">' . $attributes[3] . '</p>' : '';
 						$cap2 = strlen(trim($attributes[6])) > 0 ? '<p class="cap1">' . $attributes[6] . '</p>' : '';
@@ -312,9 +312,9 @@ function FM_TTML_bindAttachments($entryId, $folderPath, $folderURL, $content, $u
 					list($newProperty2, $onclickFlag2) = FM_TTML_createNewProperty($attributes[4], $eachImageWidth, $attributes[5]);
 					list($newProperty3, $onclickFlag3) = FM_TTML_createNewProperty($attributes[7], $eachImageWidth, $attributes[8]);
 					if ($context->getProperty('blog.displaymode','desktop')=='mobile') {
-						$buf = '<div>' . FM_TTML_getAttachmentBinder($attributes[1], $newProperty1, $folderPath, $folderURL, 1, $useAbsolutePath, $bRssMode) . "</div><div class=\"cap1\">$attributes[3]</div>";
-						$buf .= '<div>' . FM_TTML_getAttachmentBinder($attributes[4], $newProperty2, $folderPath, $folderURL, 1, $useAbsolutePath, $bRssMode) . "</div><div class=\"cap1\">$attributes[6]</div>";
-						$buf .= '<div>' . FM_TTML_getAttachmentBinder($attributes[7],$newProperty3, $folderPath, $folderURL, 1, $useAbsolutePath, $bRssMode) . "</div><div class=\"cap1\">$attributes[9]</div>";
+						$buf = '<div>' . FM_TTML_getAttachmentBinder($attributes[1], $newProperty1, $folderPath, $folderURL, 1, $useAbsolutePath, $bRssMode) . "<p class=\"cap1\">$attributes[3]</p></div>";
+						$buf .= '<div>' . FM_TTML_getAttachmentBinder($attributes[4], $newProperty2, $folderPath, $folderURL, 1, $useAbsolutePath, $bRssMode) . "<p class=\"cap1\">$attributes[6]</p></div>";
+						$buf .= '<div>' . FM_TTML_getAttachmentBinder($attributes[7],$newProperty3, $folderPath, $folderURL, 1, $useAbsolutePath, $bRssMode) . "<p class=\"cap1\">$attributes[9]</p></div>";
 					} else {
 						$cap1 = strlen(trim($attributes[3])) > 0 ? '<p class="cap1">' . $attributes[3] . '</p>' : '';
 						$cap2 = strlen(trim($attributes[6])) > 0 ? '<p class="cap1">' . $attributes[6] . '</p>' : '';

--- a/plugins/FM_TTML/ttml.php
+++ b/plugins/FM_TTML/ttml.php
@@ -269,7 +269,7 @@ function FM_TTML_bindAttachments($entryId, $folderPath, $folderURL, $content, $u
 					list($newProperty, $onclickFlag) = FM_TTML_createNewProperty($attributes[1], $contentWidth, $attributes[2]);
 
 					if ($context->getProperty('blog.displaymode','desktop')=='mobile') {
-						$buf = '<div class="imageblock center">' . FM_TTML_getAttachmentBinder($attributes[1], $newProperty, $folderPath, $folderURL, 1, $useAbsolutePath) . "</div><div>$attributes[3]</div>";
+						$buf = '<div class="imageblock center">' . FM_TTML_getAttachmentBinder($attributes[1], $newProperty, $folderPath, $folderURL, 1, $useAbsolutePath) . "</div><div class=\"cap1\">$attributes[3]</div>";
 					} else {
 						if (trim($attributes[3]) == '') {
 							$caption = '';
@@ -296,8 +296,8 @@ function FM_TTML_bindAttachments($entryId, $folderPath, $folderURL, $content, $u
 					list($newProperty1, $onclickFlag1) = FM_TTML_createNewProperty($attributes[1], $eachImageWidth, $attributes[2]);
 					list($newProperty2, $onclickFlag2) = FM_TTML_createNewProperty($attributes[4], $eachImageWidth, $attributes[5]);
 					if ($context->getProperty('blog.displaymode','desktop')=='mobile') {
-						$buf = '<div>' . FM_TTML_getAttachmentBinder($attributes[1], $newProperty1, $folderPath, $folderURL, 1, $useAbsolutePath, $bRssMode) . "</div><div>$attributes[3]</div>";
-						$buf .= '<div>' . FM_TTML_getAttachmentBinder($attributes[4], $newProperty2, $folderPath, $folderURL, 1, $useAbsolutePath, $bRssMode) . "</div><div>$attributes[6]</div>";
+						$buf = '<div>' . FM_TTML_getAttachmentBinder($attributes[1], $newProperty1, $folderPath, $folderURL, 1, $useAbsolutePath, $bRssMode) . "</div><div class=\"cap1\">$attributes[3]</div>";
+						$buf .= '<div>' . FM_TTML_getAttachmentBinder($attributes[4], $newProperty2, $folderPath, $folderURL, 1, $useAbsolutePath, $bRssMode) . "</div><div class=\"cap1\">$attributes[6]</div>";
 					} else {
 						$cap1 = strlen(trim($attributes[3])) > 0 ? '<p class="cap1">' . $attributes[3] . '</p>' : '';
 						$cap2 = strlen(trim($attributes[6])) > 0 ? '<p class="cap1">' . $attributes[6] . '</p>' : '';
@@ -312,9 +312,9 @@ function FM_TTML_bindAttachments($entryId, $folderPath, $folderURL, $content, $u
 					list($newProperty2, $onclickFlag2) = FM_TTML_createNewProperty($attributes[4], $eachImageWidth, $attributes[5]);
 					list($newProperty3, $onclickFlag3) = FM_TTML_createNewProperty($attributes[7], $eachImageWidth, $attributes[8]);
 					if ($context->getProperty('blog.displaymode','desktop')=='mobile') {
-						$buf = '<div>' . FM_TTML_getAttachmentBinder($attributes[1], $newProperty1, $folderPath, $folderURL, 1, $useAbsolutePath, $bRssMode) . "</div><div>$attributes[3]</div>";
-						$buf .= '<div>' . FM_TTML_getAttachmentBinder($attributes[4], $newProperty2, $folderPath, $folderURL, 1, $useAbsolutePath, $bRssMode) . "</div><div>$attributes[6]</div>";
-						$buf .= '<div>' . FM_TTML_getAttachmentBinder($attributes[7],$newProperty3, $folderPath, $folderURL, 1, $useAbsolutePath, $bRssMode) . "</div><div>$attributes[9]</div>";
+						$buf = '<div>' . FM_TTML_getAttachmentBinder($attributes[1], $newProperty1, $folderPath, $folderURL, 1, $useAbsolutePath, $bRssMode) . "</div><div class=\"cap1\">$attributes[3]</div>";
+						$buf .= '<div>' . FM_TTML_getAttachmentBinder($attributes[4], $newProperty2, $folderPath, $folderURL, 1, $useAbsolutePath, $bRssMode) . "</div><div class=\"cap1\">$attributes[6]</div>";
+						$buf .= '<div>' . FM_TTML_getAttachmentBinder($attributes[7],$newProperty3, $folderPath, $folderURL, 1, $useAbsolutePath, $bRssMode) . "</div><div class=\"cap1\">$attributes[9]</div>";
 					} else {
 						$cap1 = strlen(trim($attributes[3])) > 0 ? '<p class="cap1">' . $attributes[3] . '</p>' : '';
 						$cap2 = strlen(trim($attributes[6])) > 0 ? '<p class="cap1">' . $attributes[6] . '</p>' : '';


### PR DESCRIPTION
Until now, when viewing a page in a browser with mobile user agent (iPhone), imageblock captions have been displaying as a `div` under the `imageblock` div, when normal desktop views have been rendering it as `<p class="cap1">` being inside the `imageblock` div tag.

Commit a14ac491518d48e94dba8c8a1ef9410eacdfbb38 has fixed the issue where mobile doesn't add `cap1` class that is required for it to be styled correctly, but because of structure differences if existing skins were targeting `.imageblock .cap1` for example, style would still look broken.

Also, because the commit has been made on `master` branch, old 1.10 branch still hasn't received this fix. This pull request cherry-picks the former commit to 1.10 branch and makes changes to HTML output part of `ttmp.php` to make it output same code on mobile as it is on desktop.