### PR TITLE
Add option to serve responsive images through srcset

### DIFF
--- a/interface/owner/setting/entry/index.php
+++ b/interface/owner/setting/entry/index.php
@@ -269,13 +269,20 @@ if (extension_loaded('gd')) {
 										<dl id="resampling-default-line" class="line">
 											<dt><span class="label"><?php echo _t('기본 설정');?></span></dt>
 											<dd>
-												<input type="checkbox" class="checkbox" id="useResamplingAsDefault" name="useResamplingAsDefault" value="yes"<?php echo (Setting::getBlogSettingGlobal("resamplingDefault") == "yes") ? ' checked="checked"' : NULL;?> onchange="document.getElementById('useResamplingResponsive').disabled = !this.checked;" /><label for="useResamplingAsDefault"><?php echo _t('이미지 리샘플링 기능을 기본으로 사용합니다.');?> </label><br /><?php echo _t('이미지 리샘플링을 통하여 올린 이미지의 크기를 줄여 저장한 후 출력하여 블로그의 트래픽을 줄여줍니다.');?> <em><?php echo _t('이 기능을 사용하면 올린 이미지의 크기를 줄여 저장하는 과정에서 서버에 무리를 줄 수 있으니 주의하시기 바랍니다.');?></em>
+												<input type="checkbox" class="checkbox" id="useResamplingAsDefault" name="useResamplingAsDefault" value="yes"<?php echo (Setting::getBlogSettingGlobal("resamplingDefault") == "yes") ? ' checked="checked"' : NULL;?> onchange="document.getElementById('useResamplingResponsive').disabled = !this.checked;" /><label for="useResamplingAsDefault"><?php echo _t('이미지 리샘플링 기능을 기본으로 사용합니다.');?> </label>
+											</dd>
+											<dd>
+												<p><?php echo _t('이미지 리샘플링을 통하여 올린 이미지의 크기를 줄여 저장한 후 출력하여 블로그의 트래픽을 줄여줍니다.');?> <strong><?php echo _t('이 기능을 사용하면 올린 이미지의 크기를 줄여 저장하는 과정에서 서버에 무리를 줄 수 있으니 주의하시기 바랍니다.');?></strong></p>
 											</dd>
 										</dl>
 										<dl id="resampling-responsive-line" class="line">
 											<dt><span class="label"><?php echo _t('고급 설정');?></span></dt>
 											<dd>
-												<input type="checkbox" class="checkbox" id="useResamplingResponsive" name="useResamplingResponsive" value="yes"<?php echo (Setting::getBlogSettingGlobal("resamplingResponsive") == "yes") ? ' checked="checked"' : NULL;?> /><label for="useResamplingResponsive"><?php echo _t('srcset을 이용한 반응형 이미지 기능을 사용합니다.');?> </label><br /><?php echo _t('이미지의 작은 사이즈 사본을 추가적으로 생성하고, 접속한 브라우저의 화면 크기에 따라 가장 알맞은 사이즈의 이미지만 서빙하여 트래픽을 절약할 수 있습니다. IE를 제외한 모든 모던한 브라우저에서 해당 기능을 지원하며, srcset을 지원하지 않는 브라우저에서는 기본 크기의 이미지 주소를 참조합니다. 이 기능을 사용하려면, 위의 이미지 리샘플링 기능이 켜져있어야 합니다.');?></em>
+												<input type="checkbox" class="checkbox" id="useResamplingResponsive" name="useResamplingResponsive" value="yes"<?php echo (Setting::getBlogSettingGlobal("resamplingResponsive") == "yes") ? ' checked="checked"' : NULL;?> /><label for="useResamplingResponsive"><?php echo _t('srcset을 이용한 반응형 이미지 기능을 사용합니다.');?> </label>
+											</dd>
+											<dd>
+												<p><?php echo _t('이미지의 작은 사이즈 사본을 추가적으로 생성하고, 접속한 브라우저의 화면 크기에 따라 가장 알맞은 사이즈의 이미지만 서빙하여 트래픽을 절약할 수 있습니다. IE를 제외한 모든 모던한 브라우저에서 해당 기능을 지원하며, srcset을 지원하지 않는 브라우저에서는 기본 크기의 이미지 주소를 참조합니다.');?><strong><?php echo _t('이 기능을 사용하려면, 위의 이미지 리샘플링 기능이 켜져있어야 합니다.');?></strong>
+												</p>
 											</dd>
 										</dl>
 									</fieldset>

--- a/interface/owner/setting/entry/index.php
+++ b/interface/owner/setting/entry/index.php
@@ -272,6 +272,12 @@ if (extension_loaded('gd')) {
 												<input type="checkbox" class="checkbox" id="useResamplingAsDefault" name="useResamplingAsDefault" value="yes"<?php echo (Setting::getBlogSettingGlobal("resamplingDefault") == "yes") ? ' checked="checked"' : NULL;?> /><label for="useResamplingAsDefault"><?php echo _t('이미지 리샘플링 기능을 기본으로 사용합니다.');?> </label><br /><?php echo _t('이미지 리샘플링을 통하여 올린 이미지의 크기를 줄여 저장한 후 출력하여 블로그의 트래픽을 줄여줍니다.');?> <em><?php echo _t('이 기능을 사용하면 올린 이미지의 크기를 줄여 저장하는 과정에서 서버에 무리를 줄 수 있으니 주의하시기 바랍니다.');?></em>
 											</dd>
 										</dl>
+										<dl id="resampling-responsive-line" class="line">
+											<dt><span class="label"><?php echo _t('고급 설정');?></span></dt>
+											<dd>
+												<input type="checkbox" class="checkbox" id="useResamplingResponsive" name="useResamplingResponsive" value="yes"<?php echo (Setting::getBlogSettingGlobal("resamplingResponsive") == "yes") ? ' checked="checked"' : NULL;?> /><label for="useResamplingResponsive"><?php echo _t('srcset을 이용한 반응형 이미지 기능을 사용합니다.');?> </label><br /><?php echo _t('이미지의 작은 사이즈 사본을 추가적으로 생성하고, 접속한 브라우저의 화면 크기에 따라 가장 알맞은 사이즈의 이미지만 서빙하여 트래픽을 절약할 수 있습니다. IE를 제외한 모든 모던한 브라우저에서 해당 기능을 지원하며, srcset을 지원하지 않는 브라우저에서는 기본 크기의 이미지 주소를 참조합니다. 이 기능을 사용하려면, 위의 이미지 리샘플링 기능이 켜져있어야 합니다.');?></em>
+											</dd>
+										</dl>
 									</fieldset>
 									<div class="button-box">
 										<input type="submit" class="save-button input-button wide-button" value="<?php echo _t('저장하기');?>" onclick="setResample(); return false;" />

--- a/interface/owner/setting/entry/index.php
+++ b/interface/owner/setting/entry/index.php
@@ -269,7 +269,7 @@ if (extension_loaded('gd')) {
 										<dl id="resampling-default-line" class="line">
 											<dt><span class="label"><?php echo _t('기본 설정');?></span></dt>
 											<dd>
-												<input type="checkbox" class="checkbox" id="useResamplingAsDefault" name="useResamplingAsDefault" value="yes"<?php echo (Setting::getBlogSettingGlobal("resamplingDefault") == "yes") ? ' checked="checked"' : NULL;?> /><label for="useResamplingAsDefault"><?php echo _t('이미지 리샘플링 기능을 기본으로 사용합니다.');?> </label><br /><?php echo _t('이미지 리샘플링을 통하여 올린 이미지의 크기를 줄여 저장한 후 출력하여 블로그의 트래픽을 줄여줍니다.');?> <em><?php echo _t('이 기능을 사용하면 올린 이미지의 크기를 줄여 저장하는 과정에서 서버에 무리를 줄 수 있으니 주의하시기 바랍니다.');?></em>
+												<input type="checkbox" class="checkbox" id="useResamplingAsDefault" name="useResamplingAsDefault" value="yes"<?php echo (Setting::getBlogSettingGlobal("resamplingDefault") == "yes") ? ' checked="checked"' : NULL;?> onchange="document.getElementById('useResamplingResponsive').disabled = !this.checked;" /><label for="useResamplingAsDefault"><?php echo _t('이미지 리샘플링 기능을 기본으로 사용합니다.');?> </label><br /><?php echo _t('이미지 리샘플링을 통하여 올린 이미지의 크기를 줄여 저장한 후 출력하여 블로그의 트래픽을 줄여줍니다.');?> <em><?php echo _t('이 기능을 사용하면 올린 이미지의 크기를 줄여 저장하는 과정에서 서버에 무리를 줄 수 있으니 주의하시기 바랍니다.');?></em>
 											</dd>
 										</dl>
 										<dl id="resampling-responsive-line" class="line">

--- a/interface/owner/setting/entry/resample/index.php
+++ b/interface/owner/setting/entry/resample/index.php
@@ -27,7 +27,7 @@ if (isset($_POST['useResamplingResponsive']) && ($_POST['useResamplingResponsive
 	Setting::removeBlogSettingGlobal("resamplingResponsive");
 }
 
-CacheControl::flushEntry();
+CacheControl::flushAll();
 
 $isAjaxRequest ? Respond::PrintResult($errorResult) : header("Location: ".$_SERVER['HTTP_REFERER']);
 ?>

--- a/interface/owner/setting/entry/resample/index.php
+++ b/interface/owner/setting/entry/resample/index.php
@@ -5,7 +5,8 @@
 
 $IV = array(
 	'POST' => array(
-		'useResamplingAsDefault' => array('string', 'mandatory' => false)
+		'useResamplingAsDefault' => array('string', 'mandatory' => false),
+		'useResamplingResponsive' => array('string', 'mandatory' => false)
 		)
 	);
 
@@ -19,6 +20,13 @@ if (isset($_POST['useResamplingAsDefault']) && ($_POST['useResamplingAsDefault']
 } else {
 	Setting::removeBlogSettingGlobal("resamplingDefault");
 }
+
+if (isset($_POST['useResamplingResponsive']) && ($_POST['useResamplingResponsive'] == "yes")) {
+	Setting::setBlogSettingGlobal("resamplingResponsive", "yes");
+} else {
+	Setting::removeBlogSettingGlobal("resamplingResponsive");
+}
+
 CacheControl::flushEntry();
 
 $isAjaxRequest ? Respond::PrintResult($errorResult) : header("Location: ".$_SERVER['HTTP_REFERER']);

--- a/library/view/view.php
+++ b/library/view/view.php
@@ -1264,11 +1264,6 @@ function getEntryContentView($blogid, $id, $content, $formatter, $keywords = arr
 					if (file_exists(__TEXTCUBE_ATTACH_DIR__."/{$blogid}/{$tempFileName}")) {
 						$tempAttributes = Misc::getAttributesFromString($images[$i][2]);
 						$tempOriginInfo = getimagesize(__TEXTCUBE_ATTACH_DIR__."/{$blogid}/{$tempFileName}");
-						// if (isset($tempAttributes['width']) && ($tempOriginInfo[0] > $tempAttributes['width'])) {
-						// 	$image = Utils_Image::getInstance();
-
-						// 	list($resizedImageURL, $resizedImageWidth, $resizedImageHeight, $resizedImageSrc) = $image->getImageResizer($tempFileName, array('width' => $tempAttributes['width']));
-						// }
 
 						// original image
 						$absolute = isset($options['absolute']) ? $options['absolute'] : true;
@@ -1278,30 +1273,37 @@ function getEntryContentView($blogid, $id, $content, $formatter, $keywords = arr
 						$imageOrientation = ($tempOriginInfo[0]>=$tempOriginInfo[1] ? "landscape" : "portrait");
 
 
-
 						// generate small/medium images
-						if ($tempOriginInfo[0] > 360) { // 360px
-							$image = Utils_Image::getInstance();
-							list($smallImageURL, $smallImageWidth, $smallImageHeight, $smallImageSrc) = $image->getImageResizer($tempFileName, array('width' => 360));
-							
-							if ($tempOriginInfo[0] > 800) { // 800px
-								list($mediumImageURL, $mediumImageWidth, $mediumImageHeight, $mediumImageSrc) = $image->getImageResizer($tempFileName, array('width' => 800));
-
-								$baseImageURL = $mediumImageURL;
-								$baseImageWidth = $mediumImageWidth;
-								$baseImageHeight = $mediumImageHeight;
-								$srcset = "{$smallImageURL} 360w, {$mediumImageURL} 800w, {$origImageURL} {$tempOriginInfo[0]}w";
+						if (Setting::getBlogSettingGlobal('resamplingResponsive') == true) {
+							if ($tempOriginInfo[0] > 360) { // 360px
+								$image = Utils_Image::getInstance();
+								list($smallImageURL, $smallImageWidth, $smallImageHeight, $smallImageSrc) = $image->getImageResizer($tempFileName, array('width' => 360));
 								
-							} else {
-								$baseImageURL = $smallImageURL;
-								$baseImageWidth = $smallImageWidth;
-								$baseImageHeight = $smallImageHeight;
-								$srcset = "{$smallImageURL} 360w, {$origImageURL} {$tempOriginInfo[0]}w";
-							}
+								if ($tempOriginInfo[0] > 800) { // 800px
+									list($mediumImageURL, $mediumImageWidth, $mediumImageHeight, $mediumImageSrc) = $image->getImageResizer($tempFileName, array('width' => 800));
 
-							$newImage = "<img src=\"{$baseImageURL}\" srcset=\"{$srcset}\" width=\"{$tempOriginInfo[0]}\" height=\"{$tempOriginInfo[1]}\" {$attributes} data-orientation=\"{$imageOrientation}\"/>";
-						} else {
-							$newImage = "<img src=\"{$origImageURL}\" width=\"{$tempOriginInfo[0]}\" height=\"{$tempOriginInfo[1]}\" {$attributes} data-orientation=\"{$imageOrientation}\"/>";
+									$baseImageURL = $mediumImageURL;
+									$baseImageWidth = $mediumImageWidth;
+									$baseImageHeight = $mediumImageHeight;
+									$srcset = "{$smallImageURL} 360w, {$mediumImageURL} 800w, {$origImageURL} {$tempOriginInfo[0]}w";
+									
+								} else {
+									$baseImageURL = $smallImageURL;
+									$baseImageWidth = $smallImageWidth;
+									$baseImageHeight = $smallImageHeight;
+									$srcset = "{$smallImageURL} 360w, {$origImageURL} {$tempOriginInfo[0]}w";
+								}
+
+								$newImage = "<img src=\"{$baseImageURL}\" srcset=\"{$srcset}\" width=\"{$tempOriginInfo[0]}\" height=\"{$tempOriginInfo[1]}\" {$attributes} data-orientation=\"{$imageOrientation}\"/>";
+							} else {
+								$newImage = "<img src=\"{$origImageURL}\" width=\"{$tempOriginInfo[0]}\" height=\"{$tempOriginInfo[1]}\" {$attributes} data-orientation=\"{$imageOrientation}\"/>";
+							}
+						}
+						else if (isset($tempAttributes['width']) && ($tempOriginInfo[0] > $tempAttributes['width'])) {
+							$image = Utils_Image::getInstance();
+
+							list($resizedImageURL, $resizedImageWidth, $resizedImageHeight, $resizedImageSrc) = $image->getImageResizer($tempFileName, array('width' => $tempAttributes['width']));
+							$newImage = "<img src=\"{$resizedImageURL}\" width=\"{$resizedImageWidth}\" height=\"{$resizedImageHeight}\" {$attributes} data-orientation=\"{$imageOrientation}\"/>";
 						}
 					
 					}

--- a/library/view/view.php
+++ b/library/view/view.php
@@ -1269,12 +1269,16 @@ function getEntryContentView($blogid, $id, $content, $formatter, $keywords = arr
 						$origImageSrc = __TEXTCUBE_ATTACH_DIR__."/{$blogid}/{$tempFileName}";
 						$origImageURL = ($absolute ? $context->getProperty('uri.service'):$context->getProperty('uri.path'))."/attach/{$blogid}/{$tempFileName}";
 						
+						// Detect orientation
 						$imageOrientation = ($tempOriginInfo[0]>=$tempOriginInfo[1] ? "landscape" : "portrait");
+
+						// Check whether original image width is larger than resized image (blog content width)
+						$imageZoomable = ($tempOriginInfo[0]>$tempAttributes['width'] ? "true" : "false"); 
 
 
 						// generate small/medium images
 						if (Setting::getBlogSettingGlobal('resamplingResponsive') == true) {
-							if ($tempOriginInfo[0] > 360) { // 360px
+							if (isset($tempAttributes['width']) && ($tempOriginInfo[0] > 360)) { // 360px
 								$image = Utils_Image::getInstance();
 								list($smallImageURL, $smallImageWidth, $smallImageHeight, $smallImageSrc) = $image->getImageResizer($tempFileName, array('width' => 360));
 								
@@ -1293,16 +1297,16 @@ function getEntryContentView($blogid, $id, $content, $formatter, $keywords = arr
 									$srcset = "{$smallImageURL} 360w, {$origImageURL} {$tempOriginInfo[0]}w";
 								}
 
-								$newImage = "<img src=\"{$baseImageURL}\" srcset=\"{$srcset}\" width=\"{$tempOriginInfo[0]}\" height=\"{$tempOriginInfo[1]}\" {$attributes} data-orientation=\"{$imageOrientation}\"/>";
+								$newImage = "<img src=\"{$baseImageURL}\" srcset=\"{$srcset}\" width=\"{$tempAttributes['width']}\" height=\"{$tempAttributes['height']}\" {$attributes} data-orientation=\"{$imageOrientation}\" data-zoomable=\"{$imageZoomable}\" />";
 							} else {
-								$newImage = "<img src=\"{$origImageURL}\" width=\"{$tempOriginInfo[0]}\" height=\"{$tempOriginInfo[1]}\" {$attributes} data-orientation=\"{$imageOrientation}\"/>";
+								$newImage = "<img src=\"{$origImageURL}\" width=\"{$tempAttributes['width']}\" height=\"{$tempAttributes['height']}\" {$attributes} data-orientation=\"{$imageOrientation}\" data-zoomable=\"{$imageZoomable}\"/>";
 							}
 						}
 						else if (isset($tempAttributes['width']) && ($tempOriginInfo[0] > $tempAttributes['width'])) {
 							$image = Utils_Image::getInstance();
 
 							list($resizedImageURL, $resizedImageWidth, $resizedImageHeight, $resizedImageSrc) = $image->getImageResizer($tempFileName, array('width' => $tempAttributes['width']));
-							$newImage = "<img src=\"{$resizedImageURL}\" width=\"{$resizedImageWidth}\" height=\"{$resizedImageHeight}\" {$attributes} data-orientation=\"{$imageOrientation}\"/>";
+							$newImage = "<img src=\"{$resizedImageURL}\" width=\"{$resizedImageWidth}\" height=\"{$resizedImageHeight}\" {$attributes} data-orientation=\"{$imageOrientation}\" data-zoomable=\"{$imageZoomable}\"/>";
 						}
 					
 					}


### PR DESCRIPTION
텍스트큐브에 내장된 이미지 리사이저를 이용해 더 작은 크기의 이미지를 추가적으로 생성한 뒤, `srcset` 속성을 이용해 기존에 출력되는 `img`에 삽입합니다. 지원하는 브라우저 (IE제외 모든 모던한 브라우저)에서는 접속한 기기의 뷰포트 너비와 픽셀 밀도에 가장 알맞은 크기를 자동으로 감지해 해당 사이즈의 이미지만 서빙하므로, 모바일 등 작은 화면에서 원본의 큰 사진을 로딩하지 않아 트래픽을 절약하고, 반대로 기존의 기본 리샘플링 기능을 이용할때 데스크탑 (특히 고밀도 레티나 화면)에서는 이미지의 품질이 높아보이지 않는 문제를 해결했습니다. 블로그 옵션에 체크를 넣어 2단계로 기본 리샘플링->반응형 리샘플링 설정을 할수 있게 하였고, 각 설정에서 정상 동작하는 것을 테스트했습니다.

원래 개인적인 필요에 따라 `view.php`에 있던 기존 코드를 좀 엉성하게 수정해서 구현한거긴 해서 (제가 php는 익숙한 언어가 아니라..) 코드의 퀄리티가 그리 높지 않을수 있습니다. 하지만 최신 버전의 워드프레스에서도 비슷한 기능이 적용되어있고, 모바일 기기에서의 블로그 접속이 활발한 요즘에는 다른 유저들에게도 유용한 기능이 될것같아 PR해보았습니다. 제가 1.10 브랜치를 사용중인지라 1.10 기반으로 브랜치를 따서 작업했는데, 편하실대로 수정후 merge하거나 마스터 브랜치에도 적용하시면 될것같습니다.